### PR TITLE
Add linting and formatting commands and dependencies to tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.8"
 
 install:
-  - pip install tox
+  - pip3 install tox
 
 script:
   - tox

--- a/tox.ini
+++ b/tox.ini
@@ -3,5 +3,12 @@ envlist = py3
 
 [testenv]
 changedir = tests
-deps = pytest > 5
-commands = pytest {posargs}
+deps =
+    pytest > 5
+    black
+    pylint
+
+commands =
+    pytest {posargs}
+    pylint -rn -j0 setup.py gdtoolkit/ tests/
+    black --check setup.py gdtoolkit/ tests/


### PR DESCRIPTION
Using pip3 to install tox as it works on all platforms, while e.g. for me on
Linux Ubuntu-based Pop_OS! the default python is 2.7. I don't know if that's
different on servers but there are many servers based on Ubuntu.

Closes #1 