### PR TITLE
Upgrade to Python 3.7, use @dataclass, update tox config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.6"
   - "3.7"
   - "3.8"
 

--- a/gdtoolkit/__init__.py
+++ b/gdtoolkit/__init__.py
@@ -1,22 +1,13 @@
 import sys
+from dataclasses import dataclass
 
 
-class Problem:  # TODO: use dataclass if python 3.6 support is dropped
-    def __init__(self, name: str, description: str, line: int, column: int):
-        self.name = name
-        self.description = description
-        self.line = line
-        self.column = column
-
-    def __repr__(self):
-        return "Problem({})".format(
-            {
-                "name": self.name,
-                "description": self.description,
-                "line": self.line,
-                "column": self.column,
-            }
-        )
+@dataclass
+class Problem:
+    name: str
+    description: str
+    line: int
+    column: int
 
 
 def print_problem(problem, file_path):  # TODO: colors

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -7,21 +7,24 @@ import pytest
 from gdtoolkit.parser import parse
 
 
-OK_DATA_DIR = "valid-gd-scripts"
-NOK_DATA_DIR = "invalid-gd-scripts"
+OK_DATA_DIR = "./valid-gd-scripts"
+NOK_DATA_DIR = "./invalid-gd-scripts"
 GODOT_SERVER = "godot-server"
 
 
 def pytest_generate_tests(metafunc):
+    this_directory = os.path.dirname(os.path.abspath(__file__))
     if "gdscript_ok_path" in metafunc.fixturenames:
+        directory_tests = os.path.join(this_directory, OK_DATA_DIR)
         metafunc.parametrize(
             "gdscript_ok_path",
-            [os.path.join(OK_DATA_DIR, x) for x in os.listdir(OK_DATA_DIR)],
+            [os.path.join(directory_tests, f) for f in os.listdir(directory_tests)],
         )
     if "gdscript_nok_path" in metafunc.fixturenames:
+        directory_tests = os.path.join(this_directory, NOK_DATA_DIR)
         metafunc.parametrize(
             "gdscript_nok_path",
-            [os.path.join(NOK_DATA_DIR, x) for x in os.listdir(NOK_DATA_DIR)],
+            [os.path.join(directory_tests, f) for f in os.listdir(directory_tests)],
         )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,8 @@
 envlist = py3, validators
 
 [testenv:py3]
-changedir = tests
 deps =
     pytest > 5
-
 commands =
     pytest {posargs}
 
@@ -14,11 +12,9 @@ deps =
     pytest > 5
     black
     pylint
-
 commands =
     pylint -rn -j0 setup.py gdtoolkit/ tests/ --rcfile=tox.ini
     black --check setup.py gdtoolkit/ tests/
-
 
 [MESSAGES CONTROL]
 disable=


### PR DESCRIPTION
Close #6

I also modified tox and the test scripts so you only need one environment - no need to create separate pyenvs and download dependencies separately as well, that'll keep tests running faster.