### PR TITLE
Refactor parser script

### DIFF
--- a/bin/gdlint
+++ b/bin/gdlint
@@ -27,22 +27,24 @@ from gdtoolkit.linter import lint_code, DEFAULT_CONFIG
 from gdtoolkit import print_problem
 
 
-CONFIG_FILE_NAME = 'gdlintrc'
+CONFIG_FILE_NAME = "gdlintrc"
 
 
-arguments = docopt(__doc__, version='gdlint {}'.format(
-    pkg_resources.get_distribution("gdtoolkit").version))
+arguments = docopt(
+    __doc__,
+    version="gdlint {}".format(pkg_resources.get_distribution("gdtoolkit").version),
+)
 
 if not isinstance(arguments, dict):
-    print(arguments)            # stderr
+    print(arguments)  # stderr
     sys.exit(0)
 
-if arguments['--verbose']:
+if arguments["--verbose"]:
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
-if arguments['--dump-default-config']: # TODO: error handling
+if arguments["--dump-default-config"]:  # TODO: error handling
     assert not os.path.isfile(CONFIG_FILE_NAME)
-    with open(CONFIG_FILE_NAME, 'w') as fh:
+    with open(CONFIG_FILE_NAME, "w") as fh:
         fh.write(yaml.dump(DEFAULT_CONFIG.copy()))
     sys.exit(0)
 
@@ -50,12 +52,12 @@ if arguments['--dump-default-config']: # TODO: error handling
 # TODO: extract the algorithm
 search_dir = Path(os.getcwd())
 found_config_file_path = None
-while search_dir != Path('/'):
+while search_dir != Path("/"):
     file_path = os.path.join(search_dir, CONFIG_FILE_NAME)
     if os.path.isfile(file_path):
         found_config_file_path = file_path
         break
-    file_path = os.path.join(search_dir, '.{}'.format(CONFIG_FILE_NAME))
+    file_path = os.path.join(search_dir, ".{}".format(CONFIG_FILE_NAME))
     if os.path.isfile(file_path):
         found_config_file_path = file_path
         break
@@ -66,7 +68,7 @@ if found_config_file_path is None:
     config = DEFAULT_CONFIG
 else:
     logging.info("Config file found: '%s'", found_config_file_path)
-    with open(found_config_file_path, 'r') as fh:
+    with open(found_config_file_path, "r") as fh:
         config = yaml.load(fh.read(), Loader=yaml.Loader)
 
 logging.info("Loaded config:")
@@ -75,16 +77,18 @@ for entry in config.items():
 
 for key in DEFAULT_CONFIG:
     if key not in config:
-        logging.info('Adding missing entry from defaults: %s', (key, DEFAULT_CONFIG[key]))
+        logging.info(
+            "Adding missing entry from defaults: %s", (key, DEFAULT_CONFIG[key])
+        )
         config[key] = DEFAULT_CONFIG[key]
 
-for file_path in arguments['<file>']:
-    with open(file_path, 'r') as fh: # TODO: handle exception
+for file_path in arguments["<file>"]:
+    with open(file_path, "r") as fh:  # TODO: handle exception
         content = fh.read()
         problems = lint_code(content, config)
-        if len(problems) > 0:   # TODO: friendly frontend like in halint
+        if len(problems) > 0:  # TODO: friendly frontend like in halint
             for problem in problems:
                 print_problem(problem, file_path)
             sys.exit(1)
 
-logging.info('Success: no problems found')
+logging.info("Success: no problems found")

--- a/bin/gdparse
+++ b/bin/gdparse
@@ -17,21 +17,23 @@ import sys
 import pkg_resources
 
 from docopt import docopt
-from gdtoolkit.parser import parse
+from gdtoolkit.parser import parser
 
 
-arguments = docopt(__doc__, version='gdparse {}'.format(
-    pkg_resources.get_distribution("gdtoolkit").version))
+arguments = docopt(
+    __doc__,
+    version="gdparse {}".format(pkg_resources.get_distribution("gdtoolkit").version),
+)
 
 if not isinstance(arguments, dict):
     print(arguments)
     sys.exit(0)
 
-for file_path in arguments['<file>']:
-    with open(file_path, 'r') as fh: # TODO: handle exception
+for file_path in arguments["<file>"]:
+    with open(file_path, "r") as fh:  # TODO: handle exception
         content = fh.read()
-        tree = parse(content) # TODO: handle exception
-        if arguments['--pretty']:
+        tree = parser.parse(content)  # TODO: handle exception
+        if arguments["--pretty"]:
             print(tree.pretty())
-        elif arguments['--verbose']:
+        elif arguments["--verbose"]:
             print(tree)

--- a/gdtoolkit/linter/__init__.py
+++ b/gdtoolkit/linter/__init__.py
@@ -2,7 +2,7 @@ from types import MappingProxyType
 from typing import List
 
 from .. import Problem
-from ..parser import parse
+from ..parser import parser
 from . import basic_checks, class_checks, design_checks, format_checks, name_checks
 
 PASCAL_CASE = r"([A-Z][a-z0-9]*)+"
@@ -105,7 +105,7 @@ DEFAULT_CONFIG = MappingProxyType({
 def lint_code(
     gdscript_code: str, config: MappingProxyType = DEFAULT_CONFIG
 ) -> List[Problem]:
-    parse_tree = parse(gdscript_code, gather_metadata=True)
+    parse_tree = parser.parse(gdscript_code, gather_metadata=True)
     problems = design_checks.lint(parse_tree, config)
     problems += format_checks.lint(gdscript_code, config)
     problems += name_checks.lint(parse_tree, config)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,7 +4,7 @@ import shutil
 
 import pytest
 
-from gdtoolkit.parser import parse
+from gdtoolkit.parser import parser
 
 
 OK_DATA_DIR = "./valid-gd-scripts"
@@ -31,7 +31,7 @@ def pytest_generate_tests(metafunc):
 def test_parsing_success(gdscript_ok_path):
     with open(gdscript_ok_path, "r") as fh:
         code = fh.read()
-        parse(code)  # just checking if not throwing
+        parser.parse(code)  # just checking if not throwing
 
 
 @pytest.mark.skipif(shutil.which(GODOT_SERVER) is None, reason="requires godot server")
@@ -45,7 +45,7 @@ def test_parsing_failure(gdscript_nok_path):
     with open(gdscript_nok_path, "r") as fh:
         code = fh.read()
         try:
-            parse(code)
+            parser.parse(code)
         except:  # pylint: disable=bare-except
             return
         raise Exception("shall fail")


### PR DESCRIPTION
Removed global statement, simplified the parse function.
Added docstrings.
Made the code a little easier to read.

I did that because I didn't understand the parser code the first time I read it. This preserves the tests' performances while hopefully improving readability.