### PR TITLE
Fix to package.json and readme markdown to vscode extension

### DIFF
--- a/editor-plugins/vscode/CHANGELOG.md
+++ b/editor-plugins/vscode/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.2
+
+Fix to the README markdown and package.json
+
 ## 1.0.0
 
-- Initial release
+Initial release

--- a/editor-plugins/vscode/README.md
+++ b/editor-plugins/vscode/README.md
@@ -8,7 +8,7 @@ Formats GDScript code using VSCode's built-in formatters. Supports format-on-sav
 
 Usage: `ctrl`+`shift`+`P` to open the command palette. `Format Document` on a GDScript file.
 
-![Formatted output](https://github.com/Scony/godot-gdscript-toolkit/blob/vscode-plugin/editor-plugins/vscode/assets/banner.png)
+![Formatted output](editor-plugins/vscode/assets/banner.png)
 
 ## Requirements
 
@@ -24,6 +24,10 @@ Usage: `ctrl`+`shift`+`P` to open the command palette. `Format Document` on a GD
 None yet
 
 ## Release Notes
+
+### 1.0.2
+
+Fix to the README markdown and package.json
 
 ### 1.0.0
 

--- a/editor-plugins/vscode/package.json
+++ b/editor-plugins/vscode/package.json
@@ -2,8 +2,12 @@
     "name": "gdscript-toolkit-formatter",
     "displayName": "GDScript Formatter",
     "description": "Formatter for GDScript in Visual Studio Code using Scony's GDScript Toolkit",
-    "version": "1.0.0",
-    "repository": "https://github.com/Scony/godot-gdscript-toolkit",
+    "version": "1.0.2",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Scony/godot-gdscript-toolkit.git",
+        "directory": "editor-plugins/vscode"
+    },
     "publisher": "Razoric",
     "author": "Scony",
     "icon": "icon.png",


### PR DESCRIPTION
The image was broken and the package.json now points to the subdirectory, so VSCE can automatically fix URL strings and update versions.