### PR TITLE
Save document after applyEdit

### DIFF
--- a/editor-plugins/vscode/src/extension.ts
+++ b/editor-plugins/vscode/src/extension.ts
@@ -78,7 +78,7 @@ export function activate(context: vscode.ExtensionContext) {
         }
     );
 
-	context.subscriptions.push(update_formatter);
+    context.subscriptions.push(update_formatter);
     context.subscriptions.push(formatter);
     context.subscriptions.push(organize_command);
     context.subscriptions.push(convert_command);
@@ -199,7 +199,11 @@ export function applyFormat(formatted: string, document: vscode.TextDocument) {
         formatted
     );
 
-    vscode.workspace.applyEdit(edit);
+    vscode.workspace.applyEdit(edit).then((res) => {
+        if (res) {
+            document.save();
+        }
+    });
 }
 
-export function deactivate() {}
+export function deactivate() { }

--- a/editor-plugins/vscode/src/extension.ts
+++ b/editor-plugins/vscode/src/extension.ts
@@ -199,8 +199,9 @@ export function applyFormat(formatted: string, document: vscode.TextDocument) {
         formatted
     );
 
-    vscode.workspace.applyEdit(edit).then((res) => {
-        if (res) {
+    vscode.workspace.applyEdit(edit).then((success) => {
+        var format_on_save = vscode.workspace.getConfiguration("editor").formatOnSave;
+        if (success && format_on_save) {
             document.save();
         }
     });


### PR DESCRIPTION
After formatting, the document is left in an unsaved situation.
    
I checked the promise returned from `vscode.workspace.applyEdit()` and save the document when edit was success