### PR TITLE
Formatter creates invalid syntax on preload.

### DIFF
--- a/gdtoolkit/formatter/expression.py
+++ b/gdtoolkit/formatter/expression.py
@@ -37,7 +37,7 @@ def format_comma_separated_list(
     child_context = context.create_child_context(expression_context.prefix_line)
     fake_expression = Tree("fake", a_list)
     multiline_mode_forced = is_expression_forcing_multiple_lines(fake_expression)
-    if not multiline_mode_forced:
+    if not multiline_mode_forced or "preload" in expression_context.prefix_string:
         strings_to_join = list(map(standalone_expression_to_str, elements))
         single_line_expression = "{}{}{}".format(
             expression_context.prefix_string,
@@ -45,7 +45,10 @@ def format_comma_separated_list(
             expression_context.suffix_string,
         )
         single_line_length = len(single_line_expression) + context.indent
-        if single_line_length <= context.max_line_length:
+        if (
+            single_line_length <= context.max_line_length
+            or "preload" in expression_context.prefix_string
+        ):
             return [
                 (
                     expression_context.prefix_line,


### PR DESCRIPTION
Co-authored-by: K. S. Ernest (iFire) Lee <ernest.lee@chibifire.com>
```
const some_long_variable_name = preload("res://addons/long_addon_name/long_file_name.gd")
```
is formatted to
```
const some_long_variable_name = preload(
    "res://addons/long_addon_name/long_file_name.gd"
)
```

However, unlike `load`, `preload` is syntactially required to be on one line.

This works around the issue, and it fixes code which was broken by previous versions of the formatter.