### PR TITLE
gdlint: find GDScript files recursively in a directory

### DIFF
--- a/gdtoolkit/linter/__init__.py
+++ b/gdtoolkit/linter/__init__.py
@@ -76,6 +76,7 @@ DEFAULT_CONFIG = MappingProxyType(
         "max-line-length": 100,
         "mixed-tabs-and-spaces": None,
         # misc
+        "excluded_directories": {".git"},
         # no-else-return
         # never-returning-function # for non-void, typed functions
         # simplify-boolean-expression


### PR DESCRIPTION
This does the same as #76, just for gdlint.

The added Code mostly the same, except for the config-able `excluded_directories`.
I added this to exclude add-ons, that do not follow the Godot Style Guide.