### PR TITLE
Add pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,16 @@
+- id: gdlint
+  name: gdlint
+  description: "gdlint - linter for GDScript"
+  entry: gdlint
+  language: python
+  language_version: python3
+  require_serial: true
+  types: [gdscript]
+- id: gdformat
+  name: gdformat
+  description: "gdformat - formater for GDScript"
+  entry: gdformat
+  language: python
+  language_version: python3
+  require_serial: true
+  types: [gdscript]


### PR DESCRIPTION
Example of usage in your project:

File `.pre-commit-config.yaml`
``` yaml
repos:
-   repo: https://github.com/yvaucher/godot-gdscript-toolkit
    rev: add-pre-commit-hooks.yaml
    hooks:
    - id: gdlint
      # files: ".gd$"
      language: python
      language_version: python3.7
    - id: gdformat
      # files: ".gd$"
      language: python
      language_version: python3.7
```
EDIT1: `files: ".gd$"` can be omitted now that `identify` detects gdscript files.
EDIT2: `language_version` must be `python3.7` or an higher python version.

Output:

``` bash
$ pre-commit install
pre-commit installed at .git/hooks/pre-commit
$ pre-commit run -a
[INFO] Initializing environment for https://github.com/yvaucher/godot-gdscript-toolkit.
[INFO] Installing environment for https://github.com/yvaucher/godot-gdscript-toolkit.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
gdlint...................................................................Passed
gdformat.................................................................Passed
```

With some errors:

``` bash
$ pre-commit run -a
gdlint...................................................................Failed
- hook id: gdlint
- exit code: 1

src/Grid.gd:12: Error: Trailing whitespace(s) (trailing-whitespace)
src/Grid.gd:3: Error: Class name "something" is not valid (class-name)
src/Grid.gd:18: Error: Function-scope variable name "_object" is not valid (function-variable-name)
src/Grid.gd:3: Error: Definition out of order in global scope (class-definitions-order)
Failure: 4 problems found

gdformat.................................................................Failed
- hook id: gdformat
- files were modified by this hook

reformatted src/Grid.gd
1 file reformatted, 9 files left unchanged.
```

[pre-commit](https://github.com/pre-commit/pre-commit) uses identify to detect the type of file. For now it doesn't recognize `.gd` files.
Hopefully this should cover it sooner or later: https://github.com/chriskuehl/identify/pull/121 (merged :heavy_check_mark: )