### PR TITLE
Enum value expression support

### DIFF
--- a/gdtoolkit/formatter/enum.py
+++ b/gdtoolkit/formatter/enum.py
@@ -6,6 +6,7 @@ from lark import Tree, Token
 from .context import Context
 from .constants import INDENT_STRING
 from .types import Outcome
+from .expression_to_str import standalone_expression_to_str
 
 
 @dataclass
@@ -37,7 +38,7 @@ class Enum:
         for enum_element in enum_def.find_data("enum_element"):
             name = enum_element.children[0].value
             value = (
-                enum_element.children[1].value
+                standalone_expression_to_str(enum_element.children[1])
                 if len(enum_element.children) > 1
                 else None
             )
@@ -100,7 +101,7 @@ def _calculate_single_line_elements_len(enum: Enum) -> int:
     return (
         sum(
             len(element.name)
-            + (len(str(element.value)) + 3 if element.value is not None else 0)
+            + (len(element.value) + 3 if element.value is not None else 0)
             for element in enum.elements
         )
         + spaces

--- a/gdtoolkit/parser/gdscript.lark
+++ b/gdtoolkit/parser/gdscript.lark
@@ -96,7 +96,7 @@ enum_def: (enum_regular | enum_named) _NL
 enum_regular: "enum" _enum_body
 enum_named: "enum" NAME _enum_body
 _enum_body: "{" [enum_element ("," enum_element)* [trailing_comma]] "}"
-enum_element: NAME ["=" NUMBER]
+enum_element: NAME ["=" test_expr]
 
 pattern: list_pattern
 ?list_pattern: test_pattern ("," test_pattern)*

--- a/tests/formatter/input-output-pairs/enum-operations.in.gd
+++ b/tests/formatter/input-output-pairs/enum-operations.in.gd
@@ -1,0 +1,1 @@
+enum {SOME_A = 1 + 1, SOME_B= 1<<1, SOME_C = 1 if true else [1,2, 3 ] }

--- a/tests/formatter/input-output-pairs/enum-operations.out.gd
+++ b/tests/formatter/input-output-pairs/enum-operations.out.gd
@@ -1,0 +1,1 @@
+enum { SOME_A = 1 + 1, SOME_B = 1 << 1, SOME_C = 1 if true else [1, 2, 3] }

--- a/tests/valid-gd-scripts/enums.gd
+++ b/tests/valid-gd-scripts/enums.gd
@@ -30,3 +30,6 @@ enum {}
 enum Name {}
 
 enum WithNegativeElement { POS, NEG = -1 }
+
+enum WithOperator { ADD = 1 + 3, SHIFT = 1<<2 }
+enum WithIfElse { IF = 1 if true else [1,2, 3 ] }


### PR DESCRIPTION
### fixed parser for expresions in enums
### added hacky support in formatter (using standalone_expression_to_str)
Here may be need for a better solution, I think expression_to_str might cause problems for long expressions that should be multiline. (something that probably almost never happens, but still)

I am open to discussion here.

This would close #82 
