### PR TITLE
add test for master and puppet keywords

### DIFF
--- a/tests/valid-gd-scripts/master_and_puppet.gd
+++ b/tests/valid-gd-scripts/master_and_puppet.gd
@@ -1,0 +1,7 @@
+extends Node
+
+puppet func some_puppet():
+	    pass
+
+master func some_master():
+	    pass


### PR DESCRIPTION
Related to #108.
This test will fail until `puppet` is added to the grammar.

This is my first PR here, please let me know if I've done this correctly, or if I need to make any changes. I'm not familiar with how the parser/grammar works yet, but I figured at least we can avoid regression, as well as a not-so-subtle reminder that this issue should be fixed, with this test.