### PR TITLE
Add empty class test

### DIFF
--- a/tests/valid-gd-scripts/empty_class.gd
+++ b/tests/valid-gd-scripts/empty_class.gd
@@ -1,0 +1,2 @@
+class Empty:
+	pass

--- a/tests/valid-gd-scripts/master_and_puppet.gd
+++ b/tests/valid-gd-scripts/master_and_puppet.gd
@@ -1,0 +1,7 @@
+extends Node
+
+puppet func some_puppet():
+	    pass
+
+master func some_master():
+	    pass


### PR DESCRIPTION
Related to #99.

Create a test file for an "empty" class (as in, containing only `pass`) to avoid regression. This test is intended to fail until the related issue is resolved.

Note: I made a mistake when I opened https://github.com/Scony/godot-gdscript-toolkit/pull/62 in that I committed directly to my `master` branch when I should have created a patch branch. I will fix this as soon as that PR is merged and/or closed. This is the reason for https://github.com/Scony/godot-gdscript-toolkit/commit/92a729aa21202c0faec59b913b73414a4e5a6f38 appearing in this PR.