### PR TITLE
gdlint: Ensure that excluded_directories is a set

### DIFF
--- a/gdtoolkit/linter/__main__.py
+++ b/gdtoolkit/linter/__main__.py
@@ -113,7 +113,7 @@ def main():  # pylint: disable=too-many-branches
 def _find_files_from(paths: List[Path], config: dict) -> List[Path]:
     """Finds files in directories recursively and combines results to the list"""
     files = []
-    excluded_directories = config["excluded_directories"]
+    excluded_directories = set(config["excluded_directories"])
     for path in paths:
         if os.path.isdir(path):
             for dirpath, dirnames, filenames in os.walk(path, topdown=True):


### PR DESCRIPTION
If configured, the excluded_directories config item will become either
a list or a dict, depending on which YAML construct is used in the
config file. Meanwhile, the default config is a set.

With this change, it'll always be used as a set for consistency and
performance reasons.