### PR TITLE
gdformat: Format export hints with no leading space

### DIFF
--- a/gdtoolkit/formatter/class_statement.py
+++ b/gdtoolkit/formatter/class_statement.py
@@ -76,7 +76,7 @@ def _format_export_statement(statement: Tree, context: Context) -> Outcome:
         return format_var_statement(
             concrete_export_statement, context, prefix="export "
         )
-    expression_context = ExpressionContext("export (", statement.line, ")")
+    expression_context = ExpressionContext("export(", statement.line, ")")
     prefix_lines, _ = (
         format_comma_separated_list(
             concrete_export_statement.children[:-1], expression_context, context


### PR DESCRIPTION
Follows the examples in the GDScript style guide by formatting export
hints without a space before the opening parenthesis.

For example:  `export(Jobs) var job = Jobs.KNIGHT`
instead of:   `export (Jobs) var job = Jobs.KNIGHT`

Closes: #100