### PR TITLE
Bugfix: Duplicated Load Check - list index out of range with parse tree the size of two

### DIFF
--- a/gdtoolkit/linter/basic_checks.py
+++ b/gdtoolkit/linter/basic_checks.py
@@ -90,7 +90,7 @@ def _duplicated_load_check(parse_tree: Tree) -> List[Problem]:
         callee_name = name_token.value
         if (
             callee_name in ["load", "preload"]
-            and len(call.children) > 1
+            and len(call.children) > 2
             and isinstance(call.children[2], Tree)
             and call.children[2].data == "string"
         ):


### PR DESCRIPTION
Ran into an issue where the duplicated load check would get a simple index out of range error.

**Heads up, we are working off the `4.0-int` branch**

---

Here is an example of the an example of the bug in action:

Example parse tree passed as input from a real example:
```
[Token('NAME', 'load'), Tree('mdr_expr', [Tree('string', [Token('REGULAR_STRING', '"res://art/ui/icons/%s.png"')]), Token('PERCENT', '%'), Tree('getattr_call', [Tree('getattr', [Token('NAME', 'self'), Token('DOT', '.'), Token('NAME', 'get_slug')])])])]
```

Would throw:
```
Traceback (most recent call last):
  File "/home/layla/.local/bin/gdlint", line 33, in <module>
    sys.exit(load_entry_point('gdtoolkit', 'console_scripts', 'gdlint')())
  File "/home/layla/Projects/meteorite/godot-gdscript-toolkit/gdtoolkit/linter/__main__.py", line 66, in main
    problems_total += _lint_file(file_path, config)
  File "/home/layla/Projects/meteorite/godot-gdscript-toolkit/gdtoolkit/linter/__main__.py", line 134, in _lint_file
    problems = lint_code(content, config)
  File "/home/layla/Projects/meteorite/godot-gdscript-toolkit/gdtoolkit/linter/__init__.py", line 104, in lint_code
    problems += basic_checks.lint(parse_tree, config)
  File "/home/layla/Projects/meteorite/godot-gdscript-toolkit/gdtoolkit/linter/basic_checks.py", line 38, in lint
    problems = [problem for cluster in problem_clusters for problem in cluster]
  File "/home/layla/Projects/meteorite/godot-gdscript-toolkit/gdtoolkit/linter/basic_checks.py", line 38, in <listcomp>
    problems = [problem for cluster in problem_clusters for problem in cluster]
  File "/home/layla/Projects/meteorite/godot-gdscript-toolkit/gdtoolkit/linter/basic_checks.py", line 36, in <lambda>
    lambda x: x[1](parse_tree) if x[0] not in disable else [], checks_to_run_w_tree
  File "/home/layla/Projects/meteorite/godot-gdscript-toolkit/gdtoolkit/linter/basic_checks.py", line 99, in _duplicated_load_check
    if isinstance(call.children[2], Tree) and call.children[2].data == "string":
IndexError: list index out of range
```