### PR TITLE
VSCode extension: Include defaultInterpreterPath in env resolution

### DIFF
--- a/editor-plugins/vscode/src/extension.ts
+++ b/editor-plugins/vscode/src/extension.ts
@@ -82,11 +82,13 @@ export async function run_formatter(
     let options = PythonShell.defaultOptions;
     options.scriptPath = SCRIPT_PATH;
 
-    const pythonPath: string | undefined = vscode.workspace
-        .getConfiguration("python")
-        .get("pythonPath");
-    if (!!pythonPath) {
-        options.pythonPath = pythonPath;
+    const pythonConfig = vscode.workspace.getConfiguration("python");
+    for (const pathSettingKey of ["defaultInterpreterPath", "pythonPath"]) {
+        const pythonPath: string | undefined = pythonConfig.get(pathSettingKey);
+        if (!!pythonPath) {
+            options.pythonPath = pythonPath;
+            break;
+        }
     }
 
     let input = script;


### PR DESCRIPTION
This is untested and written in github's editor.

Fixes my issue in #177, although a more complete solution would do what isort does and attempt to use the [python extension's current env](https://github.com/microsoft/vscode-isort/blob/main/src/common/python.ts#L222-L265), as it is not always the same