### PR TITLE
add export standalone annotations

### DIFF
--- a/gdtoolkit/formatter/annotation.py
+++ b/gdtoolkit/formatter/annotation.py
@@ -7,7 +7,13 @@ from .context import Context, ExpressionContext
 from .expression import format_concrete_expression
 from .expression_to_str import expression_to_str
 
-STANDALONE_ANNOTATIONS = ["tool", "icon"]
+STANDALONE_ANNOTATIONS = [
+    "export_category",
+    "export_group",
+    "export_subgroup",
+    "icon",
+    "tool",
+]
 
 
 def is_non_standalone_annotation(statement: Tree) -> bool:


### PR DESCRIPTION
In Godot 4, `@export_category`, `@export_group`, and `@export_subgroup` are standalone annotations: [source](https://github.com/godotengine/godot/blob/dce1602edacd8ad96a70f29e4f524d7b7c231e3f/modules/gdscript/gdscript_parser.cpp#L143-L145).

This change will make `gdformat` correctly format these annotations to prevent `Expected newline after a standalone annotation` errors.
