### PR TITLE
Fix VSCode extension error reporting preventing compilation and bump version

### DIFF
--- a/editor-plugins/vscode/CHANGELOG.md
+++ b/editor-plugins/vscode/CHANGELOG.md
@@ -1,23 +1,39 @@
 # Change Log
 
-## 1.1.2
+### 1.2.3
 
-New command to run an update command on the godot python toolkit.
+Allow the use of defaultInterpreterPath to control python path
 
-## 1.1.1
+### 1.2.2
 
-New configuration to set the path to python, if the default is not to your liking.
+Fix formatter issue
 
-## 1.1.0
+### 1.2.1
+
+Fix scripts saving even when autosave was false
+
+### 1.2
+
+Fix save on format
+
+### 1.1.2
+
+Add the ability to update the pip package natively
+
+### 1.1.1
+
+Take the python path from VSCode configuration
+
+### 1.1.0
 
 Add the `Organize Script` and `Convert multiline comment blocks to #` commands.
 
 Fix a bug that caused the last character, if it wasn't a newline, to repeat.
 
-## 1.0.2
+### 1.0.2
 
 Fix to the README markdown and package.json
 
-## 1.0.0
+### 1.0.0
 
-Initial release
+Initial release of the VSCode extension of GDScript Formatter.

--- a/editor-plugins/vscode/README.md
+++ b/editor-plugins/vscode/README.md
@@ -35,6 +35,30 @@ A [vscode extension](https://marketplace.visualstudio.com/items?itemName=Razoric
 
 ## Release Notes
 
+### 1.2.3
+
+Allow the use of defaultInterpreterPath to control python path
+
+### 1.2.2
+
+Fix formatter issue
+
+### 1.2.1
+
+Fix scripts saving even when autosave was false
+
+### 1.2
+
+Fix save on format
+
+### 1.1.2
+
+Add the ability to update the pip package natively
+
+### 1.1.1
+
+Take the python path from VSCode configuration
+
 ### 1.1.0
 
 Add the `Organize Script` and `Convert multiline comment blocks to #` commands.

--- a/editor-plugins/vscode/package.json
+++ b/editor-plugins/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "gdscript-toolkit-formatter",
     "displayName": "GDScript Formatter",
     "description": "Formatter for GDScript in Visual Studio Code using Scony's GDScript Toolkit",
-    "version": "1.1.2",
+    "version": "1.2.3",
     "repository": {
         "type": "git",
         "url": "https://github.com/Scony/godot-gdscript-toolkit.git",
@@ -80,8 +80,8 @@
         "@typescript-eslint/parser": "^2.18.0",
         "eslint": "^6.8.0",
         "glob": "^7.1.6",
-        "mocha": "^7.2.0",
-        "typescript": "^3.7.5",
+        "mocha": "^10.1.0",
+        "typescript": "^3.9.10",
         "vscode-test": "^1.3.0"
     },
     "dependencies": {

--- a/editor-plugins/vscode/src/extension.ts
+++ b/editor-plugins/vscode/src/extension.ts
@@ -98,7 +98,7 @@ export async function run_formatter(
     try {
         return await runPythonCommand(options);
     } catch (error) {
-        onPythonError(error, uri);
+        onPythonError(error as Error, uri);
     }
 }
 


### PR DESCRIPTION
- Overdue bumping of the project
- Also fixes onPythonError preventing compilation using tsc -p