### PR TITLE
Add support for locally scoped constants

### DIFF
--- a/gdtoolkit/formatter/function_statement.py
+++ b/gdtoolkit/formatter/function_statement.py
@@ -15,6 +15,7 @@ def format_func_statement(statement: Tree, context: Context) -> Outcome:
     handlers = {
         "pass_stmt": partial(format_simple_statement, "pass"),
         "func_var_stmt": format_var_statement,
+        "const_stmt": _format_const_statement,
         "expr_stmt": _format_expr_statement,
         "return_stmt": _format_return_statement,
         "break_stmt": partial(format_simple_statement, "break"),
@@ -27,6 +28,21 @@ def format_func_statement(statement: Tree, context: Context) -> Outcome:
         "match_branch": _format_match_branch,
     }  # type: Dict[str, Callable]
     return handlers[statement.data](statement, context)
+
+
+def _format_const_statement(statement: Tree, context: Context) -> Outcome:
+    if len(statement.children) == 4:
+        prefix = f"const {statement.children[1].value} = "
+    elif len(statement.children) == 5:
+        prefix = f"const {statement.children[1].value} := "
+    elif len(statement.children) == 6:
+        prefix = (
+            f"const {statement.children[1].value}: {statement.children[3].value} = "
+        )
+    expression_context = ExpressionContext(
+        prefix, statement.line, "", statement.end_line
+    )
+    return format_expression(statement.children[-1], expression_context, context)
 
 
 def _format_expr_statement(statement: Tree, context: Context) -> Outcome:

--- a/gdtoolkit/parser/gdscript.lark
+++ b/gdtoolkit/parser/gdscript.lark
@@ -78,6 +78,7 @@ _simple_func_stmt: single_func_stmt (";" single_func_stmt)* [";"]
                  | break_stmt
                  | continue_stmt
                  | expr_stmt
+                 | const_stmt
 ?compound_func_stmt: if_stmt
                    | while_stmt
                    | for_stmt


### PR DESCRIPTION
**cat test.gd**
```gdscript
extends Node

func _ready() -> void:
	const DIRECTIONS = ["Down", "DownLeft", "Left", "UpLeft", "Up", "UpRight", "Right", "DownRight"]
	print(DIRECTIONS)
```

**gdparse test.gd**
```bash
test.gd:

const DIRECTIONS = ["Down", "DownLeft", "Left"
              ^

Unexpected token Token('TYPE_HINT', 'DIRECTIONS') at line 4, column 8.
Expected one of: 
	* ">>"
	* "+="
...
```
Currently, gdparse will fail when using locally scoped constants.

This change allows gdparse and gdformat to properly handle locally scoped `const` statements.