### PR TITLE
Fixed getattr_call expression formatting

### DIFF
--- a/gdtoolkit/formatter/expression.py
+++ b/gdtoolkit/formatter/expression.py
@@ -136,7 +136,7 @@ def _format_foldable_to_multiple_lines(
         "actual_type_cast": _format_operator_chain_based_expression_to_multiple_lines,
         "await_expr": _format_await_expression_to_multiple_lines,
         "standalone_call": _format_call_expression_to_multiple_lines,
-        "getattr_call": _collapse_to_getattr_chain_and_format_to_multiple_lines,
+        "getattr_call": _format_call_expression_to_multiple_lines,
         "getattr": _collapse_to_getattr_chain_and_format_to_multiple_lines,
         "subscr_expr": _format_subscription_to_multiple_lines,
         "par_expr": _format_parentheses_to_multiple_lines,


### PR DESCRIPTION
**DISCLAIMER**: I do not know much about the lexer and formatting in general, and my formatting expectations might not perfectly align with this project. Additionally, this might not be the most elegant solution and could potentially break other `getattr` situations.

#### Code Snippet
```gdscript
func _load_sprite_from_definition(def: Dictionary) -> void:
	for group in def["Sprite"]:
		var sprite = def["Sprite"][group]
		for field in sprite:
			match field:
				"Hframes":
					sprite["Hframes"] = int(sprite["Hframes"])
				"Vframes":
					sprite["Vframes"] = int(sprite["Vframes"])
				_:
					var defkey = _hash(sprite[field])
					if not defkey in registry["Asset"]:
						Logger.trace(0xf00003, "%s: Loading asset '%s'." % [def["DefKey"], sprite[field]])
						register({"Schema": "Asset", "DefKey": defkey, "Path": sprite[field]})
						sprite[field] = defkey
					else:
						Logger.trace(0xf00004, "%s: Asset already loaded '%s'." % [def["DefKey"], sprite[field]])
```

Running `gdformat -cd` on a file with the above snippet will attempt to incorrectly format the Logger call lines that exceed the line length as follows:

```gdscript
 				_:
 					var defkey = _hash(sprite[field])
 					if not defkey in registry["Asset"]:
						(
							Logger
							. trace(
								0xf00003, "%s: Loading asset '%s'." % [def["DefKey"], sprite[field]]
							)
						)
 						register({"Schema": "Asset", "DefKey": defkey, "Path": sprite[field]})
 						sprite[field] = defkey
 					else:
						(
							Logger
							. trace(
								0xf00004,
								"%s: Asset already loaded '%s'." % [def["DefKey"], sprite[field]]
							)
						)
```

With this change the formatting would look as follows:

```gdscript
 				_:
 					var defkey = _hash(sprite[field])
 					if not defkey in registry["Asset"]:
						Logger.trace(
							0xf00003, "%s: Loading asset '%s'." % [def["DefKey"], sprite[field]]
						)
 						register({"Schema": "Asset", "DefKey": defkey, "Path": sprite[field]})
 						sprite[field] = defkey
 					else:
						Logger.trace(
							0xf00004,
							"%s: Asset already loaded '%s'." % [def["DefKey"], sprite[field]]
						)
```