### PR TITLE
Fix some pylint problems.

### DIFF
--- a/gdtoolkit/common/ast.py
+++ b/gdtoolkit/common/ast.py
@@ -6,6 +6,7 @@ from lark import Tree
 from ..formatter.annotation import STANDALONE_ANNOTATIONS
 
 from .utils import find_name_token_among_children, find_tree_among_children
+from .exceptions import GDToolkitError
 
 
 # pylint: disable-next=too-few-public-methods
@@ -113,7 +114,7 @@ class Class:
         elif parse_tree.data == "class_def":
             self._load_data_from_class_def(parse_tree)
         else:
-            raise Exception("Cannot load class from that node")
+            raise GDToolkitError("Cannot load class from that node")
 
     def _load_data_from_node_children(self, node: Tree) -> None:
         offset = 1 if node.data == "class_def" else 0

--- a/gdtoolkit/common/exceptions.py
+++ b/gdtoolkit/common/exceptions.py
@@ -1,6 +1,10 @@
 import lark
 
 
+class GDToolkitError(Exception):
+    pass
+
+
 def lark_unexpected_input_to_str(exception: lark.exceptions.UnexpectedInput):
     return str(exception).strip()
 

--- a/gdtoolkit/formatter/exceptions.py
+++ b/gdtoolkit/formatter/exceptions.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
 
+from ..common.exceptions import GDToolkitError
+
 
 @dataclass
-class TreeInvariantViolation(Exception):
+class TreeInvariantViolation(GDToolkitError):
     diff: str
 
     def __str__(self):
@@ -10,7 +12,7 @@ class TreeInvariantViolation(Exception):
 
 
 @dataclass
-class FormattingStabilityViolation(Exception):
+class FormattingStabilityViolation(GDToolkitError):
     diff: str
 
     def __str__(self):
@@ -18,7 +20,7 @@ class FormattingStabilityViolation(Exception):
 
 
 @dataclass
-class CommentPersistenceViolation(Exception):
+class CommentPersistenceViolation(GDToolkitError):
     missing_comment: str
 
     def __str__(self):

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -58,7 +58,7 @@ def test_parsing_failure(gdscript_nok_path):
             parser.parse(code)
         except:  # pylint: disable=bare-except
             return
-        raise Exception("shall fail")
+        assert True, "shall fail"
 
 
 @pytest.mark.skipif(shutil.which(GODOT_SERVER) is None, reason="requires godot server")


### PR DESCRIPTION
Fixes problems reported by pylint which make the Github CI fail.
Implements a base class for exceptions thrown by this package `GDToolkitError`. This does not only stop pylint but could also be usefull when the project is used inside another python package.

PS:
I originally wrote gdlint because I got confused by mixing up python and GDScript.