### PR TITLE
Fix broken UTF-8 characters.

### DIFF
--- a/editor-plugins/vscode/scripts/code_formatter.py
+++ b/editor-plugins/vscode/scripts/code_formatter.py
@@ -1,5 +1,7 @@
 import sys
+import io
 from gdtoolkit.formatter import format_code
 
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
 formatted_code = format_code(sys.argv[1], int(sys.argv[2]))
 print(formatted_code)


### PR DESCRIPTION
There was a bug with converting UTF-8 double-byte characters, this fixes it by changing the output buffer to utf-8.
If you type a 2-byte character like "감사합니다" in a comment and run the formatter, you'll see that it breaks.

Thank you.