### PR TITLE
Add support for GDScript 2.0 'not in' operator

### DIFF
--- a/gdtoolkit/formatter/expression_to_str.py
+++ b/gdtoolkit/formatter/expression_to_str.py
@@ -39,8 +39,8 @@ def expression_to_str(expression: Node) -> str:
             "" if e.children[0].value == "!" else " ",
             expression_to_str(e.children[1]),
         ),
-        "content_test": _operator_chain_based_expression_to_str,
-        "asless_content_test": _operator_chain_based_expression_to_str,
+        "content_test": _content_test_expression_to_str,
+        "asless_content_test": _content_test_expression_to_str,
         "comparison": _operator_chain_based_expression_to_str,
         "asless_comparison": _operator_chain_based_expression_to_str,
         "bitw_or": _operator_chain_based_expression_to_str,
@@ -177,6 +177,10 @@ def expression_to_str(expression: Node) -> str:
             expression_to_str(e.children[0]), expression_to_str(e.children[1])
         ),
     }[expression.data](expression)
+
+
+def _content_test_expression_to_str(expression: Tree) -> str:
+    return " ".join(map(expression_to_str, expression.children))
 
 
 def _operator_chain_based_expression_to_str(expression: Tree) -> str:

--- a/gdtoolkit/parser/gdscript.lark
+++ b/gdtoolkit/parser/gdscript.lark
@@ -173,9 +173,9 @@ assnmnt_expr: attr_expr _assnmnt_op type_cast
 !?asless_actual_not_test: ("not" | "!") asless_not_test
 ?asless_not_test: asless_content_test
                 | asless_actual_not_test
-!?content_test: comparison ("in" asless_comparison)*
-              | actual_type_cast ("in" asless_comparison)+
-!?asless_content_test: asless_comparison ("in" asless_comparison)*
+!?content_test: comparison ("not"? "in" asless_comparison)*
+              | actual_type_cast ("not"? "in" asless_comparison)+
+!?asless_content_test: asless_comparison ("not"? "in" asless_comparison)*
 ?comparison: bitw_or [_comp_op asless_bitw_or]
            | actual_type_cast _comp_op asless_bitw_or
 ?asless_comparison: asless_bitw_or [_comp_op asless_bitw_or]


### PR DESCRIPTION
`x not in y` was added in Godot 4 as syntactic sugar for `not x in y`