### PR TITLE
Fix wrong code sent to exception context, fix stripped padding

### DIFF
--- a/gdtoolkit/common/exceptions.py
+++ b/gdtoolkit/common/exceptions.py
@@ -11,6 +11,6 @@ def lark_unexpected_input_to_str(exception: lark.exceptions.UnexpectedInput):
 
 def lark_unexpected_token_to_str(exception: lark.exceptions.UnexpectedToken, code: str):
     try:
-        return f"{exception.get_context(code)}\n{exception}".strip()
+        return f"{exception.get_context(code)}\n{exception}"
     except:  # pylint: disable=bare-except # noqa: E722, B001
         return f"{exception}".strip()

--- a/gdtoolkit/formatter/__main__.py
+++ b/gdtoolkit/formatter/__main__.py
@@ -202,7 +202,9 @@ def _format_code(
         success = False
         print(
             f"{file_path}:\n",
-            lark_unexpected_token_to_str(exception, code),
+            lark_unexpected_token_to_str(
+                exception, formatted_code if actually_formatted else code
+            ),
             sep="\n",
             file=sys.stderr,
         )


### PR DESCRIPTION
If lark encounters an error parsing the modified code with checks enabled then the old code was still passed as the context to the exception printing method.

Also prevent initial whitespace from being stripped from exception context message.

**Before**
```
src/Player.gd:

if b not in touching_bodies:
                             ^

Unexpected token Token('NOT', 'not') at line 181, column 9.
...
```

**After**
```
src/Player.gd:

                        if b not in touching_bodies:       
                             ^

Unexpected token Token('NOT', 'not') at line 181, column 9.
...
```
