### PR TITLE
Add gdformat config file for excluding folders.

### DIFF
--- a/gdtoolkit/formatter/__init__.py
+++ b/gdtoolkit/formatter/__init__.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from types import MappingProxyType
 from lark import Tree
 
 from ..parser import parser
@@ -9,6 +10,12 @@ from .safety_checks import (  # noqa: F401
     check_formatting_stability,
     check_comment_persistence,
     LoosenTreeTransformer,
+)
+
+DEFAULT_CONFIG = MappingProxyType(
+    {
+        "excluded_directories": {".git"},
+    }
 )
 
 

--- a/gdtoolkit/formatter/__main__.py
+++ b/gdtoolkit/formatter/__main__.py
@@ -6,6 +6,7 @@ care of by gdformat in a one, consistent way.
 
 Usage:
   gdformat <path>... [options]
+  gdformat --dump-default-config
 
 Options:
   -c --check                 Don't write the files back,
@@ -19,6 +20,7 @@ Options:
   -s --use-spaces=<int>      Use spaces for indent instead of tabs.
   -h --help                  Show this screen.
   --version                  Show version.
+  --dump-default-config      Dump default config to 'gdformatrc' file.
 
 Examples:
   echo 'pass' | gdformat -   # reads from STDIN
@@ -36,7 +38,7 @@ from docopt import docopt
 import lark
 import yaml
 
-from gdtoolkit.formatter import format_code, check_formatting_safety
+from gdtoolkit.formatter import format_code, check_formatting_safety, DEFAULT_CONFIG
 from gdtoolkit.formatter.exceptions import (
     TreeInvariantViolation,
     FormattingStabilityViolation,
@@ -48,9 +50,8 @@ from gdtoolkit.common.exceptions import (
     lark_unexpected_token_to_str,
     lark_unexpected_input_to_str,
 )
-from gdtoolkit.linter import DEFAULT_CONFIG
 
-CONFIG_FILE_NAME = "gdlintrc"
+CONFIG_FILE_NAME = "gdformatrc"
 
 
 def main():
@@ -61,6 +62,9 @@ def main():
             pkg_resources.get_distribution("gdtoolkit").version
         ),
     )
+
+    if arguments["--dump-default-config"]:
+        _dump_default_config()
 
     if arguments["--diff"]:
         arguments["--check"] = True
@@ -76,6 +80,7 @@ def main():
     config_file_path = _find_config_file()
     config = _load_config_file_or_default(config_file_path)
     _log_config_entries(config)
+    _update_config_with_missing_entries_inplace(config)
 
     files: List[str] = find_gd_files_from_paths(
         arguments["<path>"], excluded_directories=set(config["excluded_directories"])
@@ -89,6 +94,14 @@ def main():
         )
     else:
         _format_files(files, line_length, spaces_for_indent, safety_checks)
+
+
+def _dump_default_config() -> None:
+    # TODO: error handling
+    assert not os.path.isfile(CONFIG_FILE_NAME)
+    with open(CONFIG_FILE_NAME, "w", encoding="utf-8") as handle:
+        handle.write(yaml.dump(DEFAULT_CONFIG.copy()))
+    sys.exit(0)
 
 
 def _find_config_file() -> Optional[str]:
@@ -114,7 +127,7 @@ def _load_config_file_or_default(config_file_path: Optional[str]) -> MappingProx
         with open(config_file_path, "r", encoding="utf-8") as handle:
             return yaml.load(handle.read(), Loader=yaml.Loader)
 
-    logging.info("""No 'gdlintrc' nor '.gdlintrc' found. Using default config...""")
+    logging.info("""No 'gdformatrc' nor '.gdformatrc' found. Using default config...""")
     return DEFAULT_CONFIG
 
 
@@ -122,6 +135,15 @@ def _log_config_entries(config: MappingProxyType) -> None:
     logging.info("Loaded config:")
     for entry in config.items():
         logging.info(entry)
+
+
+def _update_config_with_missing_entries_inplace(config: dict) -> None:
+    for key in DEFAULT_CONFIG:
+        if key not in config:
+            logging.info(
+                "Adding missing entry from defaults: %s", (key, DEFAULT_CONFIG[key])
+            )
+            config[key] = DEFAULT_CONFIG[key]
 
 
 def _format_stdin(


### PR DESCRIPTION
This is an initial stab at fixing Issue #250

Some decisions I made that could go differently:
 - I chose to use the gdlint config file for gdformat, instead of creating a separate one for gdformat.
 - I copied over several functions rather than attempting to reference existing functions or build common libraries.

This is sort of an "easiest possible path" solution. Feel free to suggest better alternatives, but this appears to work for me.