### PR TITLE
Update GitHub actions to latest due to Node 16 deprecation.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.7'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ jobs:
     name: 'Static checks'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: Scony/godot-gdscript-toolkit@master
     - run: gdformat --check source/
     - run: gdlint source/

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
       shell: bash
 
     - id: install-python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.x"
         cache: "pip"


### PR DESCRIPTION
Older version of both the `checkout` and `setup-python` action use Node version 16, which is EOL.

`setup-python` version 5 is the first version to use Node 20 instead of 16.  
https://github.com/actions/setup-python/releases/tag/v5.0.0

`checkout` version 4 is the first version to use Node 20 instead of 16.   
https://github.com/actions/checkout/releases/tag/v4.0.0

GitHub is going to deprecate usage of Node 16 in October.  
See: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

You can see GitHub's alert about this if you view the Actions on any recent commit:  
https://github.com/Scony/godot-gdscript-toolkit/actions/runs/8214352229

This is admittedly a very trivial PR. I'm doing it because I am "in the area" and noticed and am also updating my personal repositories.  I will not be offended if you just reject this and do your own thing here.