### PR TITLE
Allow configuring indentation in VSCode extension

### DIFF
--- a/editor-plugins/vscode/package.json
+++ b/editor-plugins/vscode/package.json
@@ -59,6 +59,16 @@
                     "type": "number",
                     "default": 100,
                     "description": "The maximum size a given line can be before being wrapped."
+                },
+                "gdscript_formatter.use_spaces.enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use spaces instead of tabs for indentation"
+                },
+                "gdscript_formatter.use_spaces.count": {
+                    "type": "number",
+                    "default": 4,
+                    "description": "How many spaces to use for indenting (only used if use_spaces is enabled)"
                 }
             }
         }

--- a/editor-plugins/vscode/scripts/code_formatter.py
+++ b/editor-plugins/vscode/scripts/code_formatter.py
@@ -3,5 +3,11 @@ import io
 from gdtoolkit.formatter import format_code
 
 sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
-formatted_code = format_code(sys.argv[1], int(sys.argv[2]))
+
+formatted_code = ""
+if len(sys.argv) == 3:
+    formatted_code = format_code(sys.argv[1], int(sys.argv[2]))
+elif len(sys.argv) == 4:
+    formatted_code = format_code(sys.argv[1], int(sys.argv[2]), int(sys.argv[3]))
+
 print(formatted_code)

--- a/editor-plugins/vscode/src/extension.ts
+++ b/editor-plugins/vscode/src/extension.ts
@@ -8,13 +8,6 @@ const opn = require("opn");
 const SCRIPT_PATH = path.resolve(__dirname + "/../scripts/");
 const SCRIPT_NAME = "code_formatter.py";
 
-const PY_ARGS = [
-    "",
-    `${vscode.workspace
-        .getConfiguration("gdscript_formatter")
-        .get("line_size")}`,
-];
-
 export function activate(context: vscode.ExtensionContext) {
     let organize_command = vscode.commands.registerCommand(
         "gdscript-formatter.organize_script",
@@ -75,6 +68,30 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(convert_command);
 }
 
+function get_formatter_args(script: string): string[] {
+    let lineSize = vscode
+        .workspace
+        .getConfiguration("gdscript_formatter")
+        .get("line_size") as number;
+
+    let args = [script, String(lineSize)];
+
+    let useSpaces = vscode
+        .workspace
+        .getConfiguration("gdscript_formatter")
+        .get("use_spaces.enabled");
+
+    if (useSpaces) {
+        let nSpaces = vscode
+            .workspace
+            .getConfiguration("gdscript_formatter")
+            .get("use_spaces.count") as number;
+        args.push(String(nSpaces));
+    }
+
+    return args;
+}
+
 export async function run_formatter(
     script: string,
     uri: vscode.Uri
@@ -91,10 +108,8 @@ export async function run_formatter(
         }
     }
 
-    let input = script;
+    options.args = get_formatter_args(script);
 
-    options.args = PY_ARGS;
-    options.args[0] = input;
     try {
         return await runPythonCommand(options);
     } catch (error) {


### PR DESCRIPTION
Allows a user of the VSCode extension to configure indentation in the VSCode Extensions settings.

Tested in Extension Debug:

* Indenting using tabs (still default)
* Indenting using 4 spaces
* Indenting using 8 spaces