### PR TITLE
Support for Allman-style enum definitions

### DIFF
--- a/gdtoolkit/parser/gdscript.lark
+++ b/gdtoolkit/parser/gdscript.lark
@@ -25,7 +25,7 @@ pass_stmt: "pass"
 enum_stmt: enum_regular
          | enum_named
 enum_regular: "enum" enum_body
-enum_named: "enum" NAME enum_body
+enum_named: "enum" NAME [_NL] enum_body
 enum_body: "{" [enum_element ("," enum_element)* [trailing_comma]] "}"
 enum_element: NAME ["=" type_cast]
 signal_stmt: "signal" NAME [signal_args]


### PR DESCRIPTION
I'm not familiar with the lark format, but this change appears to support the Allman-style enums mentioned in #270, while still passing all the tox tests. 