### PR TITLE
Fix formatting of all function-specific @warning_ignore values

### DIFF
--- a/gdtoolkit/formatter/annotation.py
+++ b/gdtoolkit/formatter/annotation.py
@@ -15,8 +15,98 @@ _STANDALONE_ANNOTATIONS = [
     "icon",
     "tool",
 ]
+
+"""
+Source: https://github.com/godotengine/godot/blob/master/modules/gdscript/gdscript_warning.h
+Source last updated: 2025-01-09
+
+Unused because not applicable to functions:
+- "unused_variable"
+- "unused_local_constant"
+- "shadowed_variable"
+- "shadowed_variable_base_class"
+- "missing_tool"
+- "empty_file"
+- "unused_private_class_variable"
+- "unused_signal"
+- "redundant_static_unload"
+- "get_node_default_without_onready"
+- "onready_with_export"
+
+Unused because deprecated:
+- "property_used_as_function"
+- "constant_used_as_function"
+- "function_used_as_property"
+"""
 _NON_STANDALONE_WARNING_IGNORES = [
+    # Variable used but never assigned.
+    "unassigned_variable",
+    # Variable never assigned but used in an assignment operation (+=, *=, etc).
+    "unassigned_variable_op_assign",
+    # Function parameter is never used.
     "unused_parameter",
+    # A global class or function has the same name as variable.
+    "shadowed_global_identifier",
+    # Code after a return statement.
+    "unreachable_code",
+    # Pattern in a match statement after a catch all pattern (wildcard or bind).
+    "unreachable_pattern",
+    # Expression not assigned to a variable.
+    "standalone_expression",
+    # Return value of ternary expression is discarded.
+    "standalone_ternary",
+    # Possible values of a ternary if are not mutually compatible.
+    "incompatible_ternary",
+    # Variable/parameter/function has no static type, explicitly specified or implicitly inferred.
+    "untyped_declaration",
+    # Variable/constant/parameter has an implicitly inferred static type.
+    "inferred_declaration",
+    # Property not found in the detected type (but can be in subtypes).
+    "unsafe_property_access",
+    # Function not found in the detected type (but can be in subtypes).
+    "unsafe_method_access",
+    # Casting a `variant` value to non-`variant`.
+    "unsafe_cast",
+    # Function call argument is of a supertype of the required type.
+    "unsafe_call_argument",
+    # Function returns void but returned a call to a function that can't be type checked.
+    "unsafe_void_return",
+    # Function call returns something but the value isn't used.
+    "return_value_discarded",
+    # A static method was called on an instance of a class instead of on the class itself.
+    "static_called_on_instance",
+    # Await is used but expression is synchronous (not a signal nor a coroutine).
+    "redundant_await",
+    # Expression for assert argument is always true.
+    "assert_always_true",
+    # Expression for assert argument is always false.
+    "assert_always_false",
+    # Integer divide by integer, decimal part is discarded.
+    "integer_division",
+    # Float value into an integer slot, precision is lost.
+    "narrowing_conversion",
+    # An integer value was used as an enum value without casting.
+    "int_as_enum_without_cast",
+    # An integer value was used as an enum value without matching enum member.
+    "int_as_enum_without_match",
+    # A variable with an enum type does not have a default value. the default will be set to `0`
+    # instead of the first enum value.
+    "enum_variable_without_default",
+    # The keyword is deprecated and should be replaced.
+    "deprecated_keyword",
+    # The identifier contains misleading characters that can be confused. e.g. "usеr"
+    # (has cyrillic "е" instead of latin "e").
+    "confusable_identifier",
+    # The parent block declares an identifier with the same name below.
+    "confusable_local_declaration",
+    # The identifier will be shadowed below in the block.
+    "confusable_local_usage",
+    # Reassigning lambda capture does not modify the outer local variable.
+    "confusable_capture_reassignment",
+    # The declaration uses type inference but the value is typed as variant.
+    "inference_on_variant",
+    # The script method overrides a native one, this may not work as intended.
+    "native_method_override",
 ]
 
 

--- a/tests/formatter/input-output-pairs/simple_function_annotations.in.gd
+++ b/tests/formatter/input-output-pairs/simple_function_annotations.in.gd
@@ -34,3 +34,135 @@ func i():
 @rpc("any_peer", "call_local")
 func j():
 	pass
+
+@warning_ignore("unassigned_variable")
+func k01():
+	pass
+
+@warning_ignore("unassigned_variable_op_assign")
+func k02():
+	pass
+
+@warning_ignore("unused_parameter")
+func k03():
+	pass
+
+@warning_ignore("shadowed_global_identifier")
+func k04():
+	pass
+
+@warning_ignore("unreachable_code")
+func k05():
+	pass
+
+@warning_ignore("unreachable_pattern")
+func k06():
+	pass
+
+@warning_ignore("standalone_expression")
+func k07():
+	pass
+
+@warning_ignore("standalone_ternary")
+func k08():
+	pass
+
+@warning_ignore("incompatible_ternary")
+func k09():
+	pass
+
+@warning_ignore("untyped_declaration")
+func k10():
+	pass
+
+@warning_ignore("inferred_declaration")
+func k11():
+	pass
+
+@warning_ignore("unsafe_property_access")
+func k12():
+	pass
+
+@warning_ignore("unsafe_method_access")
+func k13():
+	pass
+
+@warning_ignore("unsafe_cast")
+func k14():
+	pass
+
+@warning_ignore("unsafe_call_argument")
+func k15():
+	pass
+
+@warning_ignore("unsafe_void_return")
+func k16():
+	pass
+
+@warning_ignore("return_value_discarded")
+func k17():
+	pass
+
+@warning_ignore("static_called_on_instance")
+func k18():
+	pass
+
+@warning_ignore("redundant_await")
+func k19():
+	pass
+
+@warning_ignore("assert_always_true")
+func k20():
+	pass
+
+@warning_ignore("assert_always_false")
+func k21():
+	pass
+
+@warning_ignore("integer_division")
+func k22():
+	pass
+
+@warning_ignore("narrowing_conversion")
+func k23():
+	pass
+
+@warning_ignore("int_as_enum_without_cast")
+func k24():
+	pass
+
+@warning_ignore("int_as_enum_without_match")
+func k25():
+	pass
+
+@warning_ignore("enum_variable_without_default")
+func k26():
+	pass
+
+@warning_ignore("deprecated_keyword")
+func k27():
+	pass
+
+@warning_ignore("confusable_identifier")
+func k28():
+	pass
+
+@warning_ignore("confusable_local_declaration")
+func k29():
+	pass
+
+@warning_ignore("confusable_local_usage")
+func k30():
+	pass
+
+@warning_ignore("confusable_capture_reassignment")
+func k31():
+	pass
+
+@warning_ignore("inference_on_variant")
+func k32():
+	pass
+
+@warning_ignore("native_method_override")
+func k33():
+	pass

--- a/tests/formatter/input-output-pairs/simple_function_annotations.out.gd
+++ b/tests/formatter/input-output-pairs/simple_function_annotations.out.gd
@@ -60,3 +60,168 @@ func i():
 @rpc("any_peer", "call_local")
 func j():
 	pass
+
+
+@warning_ignore("unassigned_variable")
+func k01():
+	pass
+
+
+@warning_ignore("unassigned_variable_op_assign")
+func k02():
+	pass
+
+
+@warning_ignore("unused_parameter")
+func k03():
+	pass
+
+
+@warning_ignore("shadowed_global_identifier")
+func k04():
+	pass
+
+
+@warning_ignore("unreachable_code")
+func k05():
+	pass
+
+
+@warning_ignore("unreachable_pattern")
+func k06():
+	pass
+
+
+@warning_ignore("standalone_expression")
+func k07():
+	pass
+
+
+@warning_ignore("standalone_ternary")
+func k08():
+	pass
+
+
+@warning_ignore("incompatible_ternary")
+func k09():
+	pass
+
+
+@warning_ignore("untyped_declaration")
+func k10():
+	pass
+
+
+@warning_ignore("inferred_declaration")
+func k11():
+	pass
+
+
+@warning_ignore("unsafe_property_access")
+func k12():
+	pass
+
+
+@warning_ignore("unsafe_method_access")
+func k13():
+	pass
+
+
+@warning_ignore("unsafe_cast")
+func k14():
+	pass
+
+
+@warning_ignore("unsafe_call_argument")
+func k15():
+	pass
+
+
+@warning_ignore("unsafe_void_return")
+func k16():
+	pass
+
+
+@warning_ignore("return_value_discarded")
+func k17():
+	pass
+
+
+@warning_ignore("static_called_on_instance")
+func k18():
+	pass
+
+
+@warning_ignore("redundant_await")
+func k19():
+	pass
+
+
+@warning_ignore("assert_always_true")
+func k20():
+	pass
+
+
+@warning_ignore("assert_always_false")
+func k21():
+	pass
+
+
+@warning_ignore("integer_division")
+func k22():
+	pass
+
+
+@warning_ignore("narrowing_conversion")
+func k23():
+	pass
+
+
+@warning_ignore("int_as_enum_without_cast")
+func k24():
+	pass
+
+
+@warning_ignore("int_as_enum_without_match")
+func k25():
+	pass
+
+
+@warning_ignore("enum_variable_without_default")
+func k26():
+	pass
+
+
+@warning_ignore("deprecated_keyword")
+func k27():
+	pass
+
+
+@warning_ignore("confusable_identifier")
+func k28():
+	pass
+
+
+@warning_ignore("confusable_local_declaration")
+func k29():
+	pass
+
+
+@warning_ignore("confusable_local_usage")
+func k30():
+	pass
+
+
+@warning_ignore("confusable_capture_reassignment")
+func k31():
+	pass
+
+
+@warning_ignore("inference_on_variant")
+func k32():
+	pass
+
+
+@warning_ignore("native_method_override")
+func k33():
+	pass


### PR DESCRIPTION
Thanks for fixing #267! I've gone through the [Godot source code](https://github.com/godotengine/godot/blob/master/modules/gdscript/gdscript_warning.h) to add _all_ the remaining warnings with the motivation behind each addition/omission. It's a little tricky to decide whether they apply to functions or not, so please let me know if you disagree with anything.

Thanks again!