### PR TITLE
Fix for line_length not being read from gdformatrc

### DIFF
--- a/gdtoolkit/formatter/__init__.py
+++ b/gdtoolkit/formatter/__init__.py
@@ -17,7 +17,7 @@ DEFAULT_CONFIG = MappingProxyType(
         "excluded_directories": {".git"},
         "safety_checks": None,
         "use_spaces": None,
-        "line_length": None,
+        "line_length": 100,
     }
 )
 

--- a/gdtoolkit/formatter/__main__.py
+++ b/gdtoolkit/formatter/__main__.py
@@ -16,7 +16,6 @@ Options:
                              (implies --check).
   -f --fast                  Skip safety checks.
   -l --line-length=<int>     How many characters per line to allow.
-                             [default: 100]
   -s --use-spaces=<int>      Use spaces for indent instead of tabs.
   -h --help                  Show this screen.
   --version                  Show version.


### PR DESCRIPTION
Removed the default value from --line-length, since this is now handled by the config.
Fixes #361 