### PR TITLE
fix: Formatter adding extra parentheses around operator chaining expressions inside function calls and arrays

### DIFF
--- a/gdtoolkit/formatter/context.py
+++ b/gdtoolkit/formatter/context.py
@@ -54,3 +54,4 @@ class ExpressionContext:
     prefix_line: int  # earliest line number of prefix string
     suffix_string: str
     suffix_line: int  # earliest line number of suffix string
+    is_inside_list: bool = False

--- a/tests/formatter/input-output-pairs/bug_305_multiline_lists_extra_parenthesis.in.gd
+++ b/tests/formatter/input-output-pairs/bug_305_multiline_lists_extra_parenthesis.in.gd
@@ -1,0 +1,21 @@
+func _ready():
+	print("Long string with added formatting %d and %s ......................................." % [1, "string"])
+	print("Long string with added formatting %d and %s ......................................." % [1, "string"], "Long string with added formatting %d and %s ......................................." % [1, "string"])
+
+	var very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii: int = 0
+	var very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii: int = 1
+
+	print(very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii + very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii)
+	print(very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii + very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii, very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii - very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii, very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii * very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii, very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii / very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii, very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii & very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii, very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii | very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii)
+
+	var array1 = ["Long string with added formatting %d and %s ......................................." % [1, "string"], very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii + very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii]
+	print(array1)
+
+	var array2 = ["Long string with added formatting %d and %s ......................................." % [1, "string"]]
+	print(array2)
+
+	var array3 = [very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii + very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii]
+	print(array3)
+
+	var array4 = [very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii + very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii,]
+	print(array4)

--- a/tests/formatter/input-output-pairs/bug_305_multiline_lists_extra_parenthesis.out.gd
+++ b/tests/formatter/input-output-pairs/bug_305_multiline_lists_extra_parenthesis.out.gd
@@ -1,0 +1,59 @@
+func _ready():
+	print(
+		"Long string with added formatting %d and %s ......................................."
+		% [1, "string"]
+	)
+	print(
+		"Long string with added formatting %d and %s ......................................."
+		% [1, "string"],
+		"Long string with added formatting %d and %s ......................................."
+		% [1, "string"]
+	)
+
+	var very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii: int = 0
+	var very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii: int = 1
+
+	print(
+		very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii
+		+ very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii
+	)
+	print(
+		very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii
+		+ very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii,
+		very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii
+		- very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii,
+		very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii
+		* very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii,
+		very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii
+		/ very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii,
+		very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii
+		& very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii,
+		very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii
+		| very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii
+	)
+
+	var array1 = [
+		"Long string with added formatting %d and %s ......................................."
+		% [1, "string"],
+		very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii
+		+ very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii
+	]
+	print(array1)
+
+	var array2 = [
+		"Long string with added formatting %d and %s ......................................."
+		% [1, "string"]
+	]
+	print(array2)
+
+	var array3 = [
+		very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii
+		+ very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii
+	]
+	print(array3)
+
+	var array4 = [
+		very_long_variable_name1_iiiiiiiiiiiiiiiiiiiiii
+		+ very_long_variable_name2_iiiiiiiiiiiiiiiiiiiiii,
+	]
+	print(array4)

--- a/tests/formatter/input-output-pairs/bug_334_multiline_lambda.out.gd
+++ b/tests/formatter/input-output-pairs/bug_334_multiline_lambda.out.gd
@@ -6,12 +6,10 @@ class WeaponSystemBullet:
 func foo():
 	var bullet_scene
 	assert(
-		(
-			(func() -> bool:
-				var test_instance: Node = bullet_scene.instantiate()
-				var is_needed_class: bool = test_instance is WeaponSystemBullet
-				test_instance.free()
-				return is_needed_class)
-			. call()
-		)
+		(func() -> bool:
+			var test_instance: Node = bullet_scene.instantiate()
+			var is_needed_class: bool = test_instance is WeaponSystemBullet
+			test_instance.free()
+			return is_needed_class)
+		. call()
 	)


### PR DESCRIPTION
This closes #305

I changed the way `_format_operator_chain_based_expression_to_multiple_lines` wraps long expressions in parentheses.

To achieve this, I pass around `is_inside_list` in the `ExpressionContext` way back from the `_format_comma_separated_list_to_multiple_lines`. Unfortunately, that means that `_format_contextless_comma_separated_list_to_multiple_lines` and `_format_contextless_operator_chain_based_expression_to_multiple_lines` are now not truly contextless.