### PR TITLE
Add gdformat --reorder-code to reorder class-level definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+ - Added `gdformat --reorder-code` to reorder class-level definitions into the canonical order checked by gdlint's `class-definitions-order` rule
+
 ## [4.5.0] 2025-10-09
 
 ### Added

--- a/gdtoolkit/common/ordering.py
+++ b/gdtoolkit/common/ordering.py
@@ -1,0 +1,86 @@
+"""Canonical ordering of class-level definitions.
+
+Shared between the linter (``class-definitions-order`` check) and the formatter
+(``gdformat --reorder-code``) so that code emitted by the formatter never trips
+the linter's ordering rule.
+"""
+from .ast import Statement, Annotation
+from .utils import find_name_token_among_children
+
+
+DEFAULT_CLASS_DEFINITIONS_ORDER = [
+    "tools",
+    "classnames",
+    "extends",
+    "docstrings",
+    "signals",
+    "enums",
+    "consts",
+    "staticvars",
+    "exports",
+    "pubvars",
+    "prvvars",
+    "onreadypubvars",
+    "onreadyprvvars",
+    "others",
+]
+
+
+def is_statement_irrelevant(statement: Statement) -> bool:
+    """Statements the ordering rule ignores: ``pass``, nested classes and
+    non-``@tool`` standalone annotations (which decorate the next statement)."""
+    if statement.kind == "pass_stmt":
+        return True
+    if statement.kind == "annotation":
+        return Annotation(statement.lark_node).name != "tool"
+    if statement.kind == "class_def":
+        return True
+    return False
+
+
+# pylint: disable-next=too-many-return-statements, too-many-branches
+def map_statement_to_section(statement: Statement) -> str:
+    if statement.kind == "class_var_stmt":
+        if any(
+            annotation.name.startswith("export") for annotation in statement.annotations
+        ):
+            return "exports"
+        if any(annotation.name == "onready" for annotation in statement.annotations):
+            return "onready{}vars".format(
+                _class_var_stmt_visibility(statement.lark_node)
+            )
+        return "{}vars".format(_class_var_stmt_visibility(statement.lark_node))
+    if statement.kind == "signal_stmt":
+        return "signals"
+    if statement.kind == "extends_stmt":
+        return "extends"
+    if statement.kind == "classname_extends_stmt":
+        return "extends"
+    if statement.kind == "enum_stmt":
+        return "enums"
+    if statement.kind == "classname_stmt":
+        return "classnames"
+    if statement.kind == "const_stmt":
+        return "consts"
+    if (
+        statement.kind == "annotation"
+        and Annotation(statement.lark_node).name == "tool"
+    ):
+        return "tools"
+    if statement.kind == "func_def":
+        return "others"
+    if statement.kind == "static_func_def":
+        return "others"
+    if statement.kind == "abstract_func_def":
+        return "others"
+    if statement.kind == "docstr_stmt":
+        return "docstrings"
+    if statement.kind == "static_class_var_stmt":
+        return "staticvars"
+    raise NotImplementedError
+
+
+def _class_var_stmt_visibility(class_var_stmt) -> str:
+    some_var_stmt = class_var_stmt.children[0]
+    name_token = find_name_token_among_children(some_var_stmt)
+    return "pub" if not name_token.value.startswith("_") else "prv"  # type: ignore

--- a/gdtoolkit/formatter/__init__.py
+++ b/gdtoolkit/formatter/__init__.py
@@ -18,6 +18,7 @@ DEFAULT_CONFIG = MappingProxyType(
         "safety_checks": None,
         "use_spaces": None,
         "line_length": 100,
+        "reorder_code": False,
     }
 )
 
@@ -32,6 +33,7 @@ def check_formatting_safety(
     given_code_parse_tree: Optional[Tree] = None,
     given_code_comment_parse_tree: Optional[Tree] = None,
     spaces_for_indent: Optional[int] = None,
+    reorder_code: bool = False,
 ) -> None:
     if given_code == formatted_code:
         return
@@ -48,6 +50,7 @@ def check_formatting_safety(
         formatted_code,
         given_code_parse_tree=given_code_parse_tree,
         formatted_code_parse_tree=formatted_code_parse_tree,
+        reorder_code=reorder_code,
     )
     check_formatting_stability(
         formatted_code,
@@ -55,4 +58,5 @@ def check_formatting_safety(
         parse_tree=formatted_code_parse_tree,
         comment_parse_tree=formatted_code_comment_parse_tree,
         spaces_for_indent=spaces_for_indent,
+        reorder_code=reorder_code,
     )

--- a/gdtoolkit/formatter/__main__.py
+++ b/gdtoolkit/formatter/__main__.py
@@ -17,6 +17,8 @@ Options:
   -f --fast                  Skip safety checks.
   -l --line-length=<int>     How many characters per line to allow.
   -s --use-spaces=<int>      Use spaces for indent instead of tabs.
+  -r --reorder-code          Reorder class-level definitions into the canonical
+                             order checked by gdlint's class-definitions-order.
   -h --help                  Show this screen.
   --version                  Show version.
   --dump-default-config      Dump default config to 'gdformatrc' file.
@@ -94,14 +96,27 @@ def main():
         else config.get("safety_checks", DEFAULT_CONFIG["safety_checks"])
     )
 
+    reorder_code = (
+        arguments["--reorder-code"]
+        if arguments.get("--reorder-code")
+        else config.get("reorder_code", DEFAULT_CONFIG["reorder_code"])
+    )
+
     if files == ["-"]:
-        _format_stdin(line_length, spaces_for_indent, safety_checks)
+        _format_stdin(line_length, spaces_for_indent, safety_checks, reorder_code)
     elif arguments["--check"]:
         _check_files_formatting(
-            files, line_length, spaces_for_indent, arguments["--diff"], safety_checks
+            files,
+            line_length,
+            spaces_for_indent,
+            arguments["--diff"],
+            safety_checks,
+            reorder_code,
         )
     else:
-        _format_files(files, line_length, spaces_for_indent, safety_checks)
+        _format_files(
+            files, line_length, spaces_for_indent, safety_checks, reorder_code
+        )
 
 
 def _dump_default_config() -> None:
@@ -155,24 +170,28 @@ def _update_config_with_missing_entries_inplace(config: dict) -> None:
 
 
 def _format_stdin(
-    line_length: int, spaces_for_indent: Optional[int], safety_checks: bool
+    line_length: int,
+    spaces_for_indent: Optional[int],
+    safety_checks: bool,
+    reorder_code: bool,
 ) -> None:
     code = sys.stdin.read()
     success, _, formatted_code = _format_code(
-        code, line_length, spaces_for_indent, "STDIN", safety_checks
+        code, line_length, spaces_for_indent, "STDIN", safety_checks, reorder_code
     )
     if not success:
         sys.exit(1)
     print(formatted_code, end="")
 
 
-# pylint: disable-next=too-many-locals
+# pylint: disable-next=too-many-locals, too-many-arguments, too-many-positional-arguments
 def _check_files_formatting(
     files: List[str],
     line_length: int,
     spaces_for_indent: Optional[int],
     print_diff: bool,
     safety_checks: bool,
+    reorder_code: bool,
 ) -> None:
     formattable_files = set()
     failed_files = set()
@@ -181,7 +200,12 @@ def _check_files_formatting(
             with open(file_path, "r", encoding="utf-8") as handle:
                 code = handle.read()
                 success, actually_formatted, formatted_code = _format_code(
-                    code, line_length, spaces_for_indent, file_path, safety_checks
+                    code,
+                    line_length,
+                    spaces_for_indent,
+                    file_path,
+                    safety_checks,
+                    reorder_code,
                 )
                 if success and actually_formatted:
                     print(f"would reformat {file_path}", file=sys.stderr)
@@ -228,11 +252,13 @@ def _check_files_formatting(
     sys.exit(1)
 
 
+# pylint: disable-next=too-many-locals
 def _format_files(
     files: List[str],
     line_length: int,
     spaces_for_indent: Optional[int],
     safety_checks: bool,
+    reorder_code: bool,
 ) -> None:
     formatted_files = set()
     failed_files = set()
@@ -241,7 +267,12 @@ def _format_files(
             with open(file_path, "r+", encoding="utf-8") as handle:
                 code = handle.read()
                 success, actually_formatted, formatted_code = _format_code(
-                    code, line_length, spaces_for_indent, file_path, safety_checks
+                    code,
+                    line_length,
+                    spaces_for_indent,
+                    file_path,
+                    safety_checks,
+                    reorder_code,
                 )
                 if success and actually_formatted:
                     print(f"reformatted {file_path}")
@@ -270,12 +301,14 @@ def _format_files(
     sys.exit(0 if len(failed_files) == 0 else 1)
 
 
+# pylint: disable-next=too-many-arguments, too-many-positional-arguments
 def _format_code(
     code: str,
     line_length: int,
     spaces_for_indent: Optional[int],
     file_path: str,
     safety_checks: bool,
+    reorder_code: bool = False,
 ) -> Tuple[bool, bool, str]:
     success = True
     actually_formatted = False
@@ -290,6 +323,7 @@ def _format_code(
             spaces_for_indent=spaces_for_indent,
             parse_tree=code_parse_tree,
             comment_parse_tree=comment_parse_tree,
+            reorder_code=reorder_code,
         )
         if formatted_code != code:
             actually_formatted = True
@@ -301,6 +335,7 @@ def _format_code(
                     spaces_for_indent=spaces_for_indent,
                     given_code_parse_tree=code_parse_tree,
                     given_code_comment_parse_tree=comment_parse_tree,
+                    reorder_code=reorder_code,
                 )
     except lark.exceptions.UnexpectedToken as exception:
         success = False

--- a/gdtoolkit/formatter/formatter.py
+++ b/gdtoolkit/formatter/formatter.py
@@ -19,7 +19,38 @@ from .comments import (
 )
 
 
+# pylint: disable-next=too-many-arguments, too-many-positional-arguments
 def format_code(
+    gdscript_code: str,
+    max_line_length: int,
+    spaces_for_indent: Optional[int] = None,
+    parse_tree: Optional[Tree] = None,
+    comment_parse_tree: Optional[Tree] = None,
+    reorder_code: bool = False,
+) -> str:
+    formatted_code = _format_code_once(
+        gdscript_code,
+        max_line_length,
+        spaces_for_indent,
+        parse_tree,
+        comment_parse_tree,
+    )
+    if reorder_code:
+        # Imported lazily to avoid an import cycle: common.ast pulls in the
+        # formatter package, and reordering depends on common.ast.
+        # pylint: disable-next=import-outside-toplevel
+        from .reordering import reorder_class_members
+
+        reordered_code = reorder_class_members(formatted_code)
+        if reordered_code != formatted_code:
+            # Reformat to normalize blank-line spacing between the moved members.
+            formatted_code = _format_code_once(
+                reordered_code, max_line_length, spaces_for_indent
+            )
+    return formatted_code
+
+
+def _format_code_once(
     gdscript_code: str,
     max_line_length: int,
     spaces_for_indent: Optional[int] = None,

--- a/gdtoolkit/formatter/reordering.py
+++ b/gdtoolkit/formatter/reordering.py
@@ -1,0 +1,147 @@
+"""Reorders class-level members so the output satisfies the linter's
+``class-definitions-order`` rule.
+
+This runs *after* a normal formatting pass, so the input here is already
+canonical: one statement per line region, ``;``-joined statements split,
+annotations on their own lines and comments placed. That lets us reorder by
+moving whole contiguous line-blocks (which carry their leading comments,
+annotations and trailing property bodies with them) and then reformat once more
+to normalize the blank-line spacing between members.
+"""
+from typing import List
+
+from lark import Tree, Token
+
+from ..parser import parser
+from ..common.ast import Statement, Annotation
+from ..common.ordering import DEFAULT_CLASS_DEFINITIONS_ORDER, map_statement_to_section
+from .annotation import is_non_standalone_annotation
+
+
+# pylint: disable-next=too-few-public-methods
+class _Member:
+    """A reorderable class-level member: its anchor statement, the non-standalone
+    annotations attached to it, and the last source line it occupies."""
+
+    def __init__(self, anchor: Tree, annotations: List[Tree], end_line: int):
+        self.anchor = anchor
+        self.annotations = annotations
+        self.end_line = end_line
+
+    @property
+    def kind(self) -> str:
+        return self.anchor.data
+
+
+def reorder_class_members(formatted_code: str) -> str:
+    parse_tree = parser.parse(formatted_code, gather_metadata=True)
+    lines = formatted_code.split("\n")
+    reordered = _reorder_scope(
+        parse_tree, 1, len(lines), lines, DEFAULT_CLASS_DEFINITIONS_ORDER
+    )
+    return "\n".join(reordered)
+
+
+# pylint: disable-next=too-many-locals
+def _reorder_scope(
+    scope: Tree,
+    body_start: int,
+    body_end: int,
+    lines: List[str],
+    order: List[str],
+) -> List[str]:
+    members = _scan_members(_scope_body_children(scope))
+    blocks = []  # type: List[tuple]
+    cursor = body_start
+    # Rank used for `pass` statements - they stick to the section they follow so
+    # they never jump around (the ordering rule ignores them).
+    running_rank = 0
+    for index, member in enumerate(members):
+        block_end = member.end_line
+        if member.kind == "class_def":
+            header_line = member.anchor.meta.line
+            inner = _reorder_scope(
+                member.anchor, header_line + 1, block_end, lines, order
+            )
+            block_lines = lines[cursor - 1 : header_line] + inner
+            rank = order.index("others")
+        elif member.kind == "pass_stmt":
+            block_lines = lines[cursor - 1 : block_end]
+            rank = running_rank
+        else:
+            block_lines = lines[cursor - 1 : block_end]
+            rank = order.index(map_statement_to_section(_as_statement(member)))
+            running_rank = rank
+        blocks.append((rank, index, block_lines))
+        cursor = block_end + 1
+
+    tail = lines[cursor - 1 : body_end]
+    blocks.sort(key=lambda block: (block[0], block[1]))
+
+    result = []  # type: List[str]
+    for _, _, block_lines in blocks:
+        result += block_lines
+    result += tail
+    return result
+
+
+def _scope_body_children(scope: Tree) -> List[Tree]:
+    """Statement/annotation nodes forming a class body, in source order.
+
+    For a nested ``class_def`` the class name token and any header ``extends``
+    (which share the header line) are excluded - only body members are returned.
+    """
+    if scope.data == "class_def":
+        header_line = scope.meta.line
+        return [
+            child
+            for child in scope.children
+            if isinstance(child, Tree) and child.meta.line > header_line
+        ]
+    return [child for child in scope.children if isinstance(child, Tree)]
+
+
+def _scan_members(children: List[Tree]) -> List[_Member]:
+    members = []  # type: List[_Member]
+    pending_annotations = []  # type: List[Tree]
+    for node in children:
+        if node.data == "annotation":
+            if node.children[0].value == "tool":
+                members.append(_Member(node, [], node.meta.end_line))
+            elif is_non_standalone_annotation(node):
+                pending_annotations.append(node)
+            # Other standalone annotations (@export_group, @icon, @abstract, ...)
+            # decorate the following member and ride along as its leading lines.
+            continue
+        if node.data == "property_body_def":
+            if members:
+                members[-1].end_line = _last_content_line(node)
+            continue
+        members.append(
+            _Member(node, list(pending_annotations), _last_content_line(node))
+        )
+        pending_annotations = []
+    return members
+
+
+def _last_content_line(node: Tree) -> int:
+    """Last source line actually occupied by ``node``.
+
+    ``meta.end_line`` is unreliable here: lark inflates it with trailing blank
+    lines and ``_DEDENT`` tokens (e.g. a function's ``end_line`` can point at the
+    next statement). The largest line among real descendant tokens, falling back
+    to each subtree's start line, gives the true last line of content.
+    """
+    last_line = node.meta.line
+    for child in node.children:
+        if isinstance(child, Token):
+            last_line = max(last_line, child.end_line)
+        elif isinstance(child, Tree):
+            last_line = max(last_line, _last_content_line(child))
+    return last_line
+
+
+def _as_statement(member: _Member) -> Statement:
+    return Statement(
+        member.anchor, [Annotation(annotation) for annotation in member.annotations]
+    )

--- a/gdtoolkit/formatter/safety_checks.py
+++ b/gdtoolkit/formatter/safety_checks.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union
 import difflib
 
 from lark import Tree, Transformer, Token
@@ -112,6 +112,7 @@ def check_tree_invariant(
     formatted_code: str,
     given_code_parse_tree: Optional[Tree] = None,
     formatted_code_parse_tree: Optional[Tree] = None,
+    reorder_code: bool = False,
 ) -> None:
     given_code_parse_tree = (
         given_code_parse_tree
@@ -128,6 +129,12 @@ def check_tree_invariant(
     formatted_code_parse_tree = loosen_tree_transformer.transform(
         formatted_code_parse_tree
     )
+    if reorder_code:
+        # Reordering deliberately permutes class-body members, so compare the
+        # trees order-insensitively at class scope. This still catches any member
+        # being added, removed or mutated.
+        given_code_parse_tree = _sort_class_body_children(given_code_parse_tree)
+        formatted_code_parse_tree = _sort_class_body_children(formatted_code_parse_tree)
     if given_code_parse_tree != formatted_code_parse_tree:
         diff = "\n".join(
             difflib.unified_diff(
@@ -138,12 +145,33 @@ def check_tree_invariant(
         raise TreeInvariantViolation(diff)
 
 
+def _sort_class_body_children(node: Tree) -> Tree:
+    """Return a copy of the tree with ``start``/``class_def`` body children sorted
+    by a canonical key, so member order no longer affects equality."""
+    new_children = [
+        _sort_class_body_children(child) if isinstance(child, Tree) else child
+        for child in node.children
+    ]
+    if node.data == "start":
+        new_children = sorted(new_children, key=_canonical_key)
+    elif node.data == "class_def":
+        # Keep the leading class-name token (and header) in place; sort the body.
+        new_children = new_children[:1] + sorted(new_children[1:], key=_canonical_key)
+    return Tree(node.data, new_children)
+
+
+def _canonical_key(node: Union[Tree, Token]) -> str:
+    return node.pretty() if isinstance(node, Tree) else repr(node)
+
+
+# pylint: disable-next=too-many-arguments, too-many-positional-arguments
 def check_formatting_stability(
     formatted_code: str,
     max_line_length: int,
     parse_tree: Optional[Tree] = None,
     comment_parse_tree: Optional[Tree] = None,
     spaces_for_indent: Optional[int] = None,
+    reorder_code: bool = False,
 ) -> None:
     code_formatted_again = format_code(
         formatted_code,
@@ -151,6 +179,7 @@ def check_formatting_stability(
         parse_tree=parse_tree,
         comment_parse_tree=comment_parse_tree,
         spaces_for_indent=spaces_for_indent,
+        reorder_code=reorder_code,
     )
     if formatted_code != code_formatted_again:
         diff = "\n".join(

--- a/gdtoolkit/linter/__init__.py
+++ b/gdtoolkit/linter/__init__.py
@@ -5,6 +5,7 @@ from typing import List, Dict, Set
 
 from .problem import Problem
 from ..parser import parser
+from ..common.ordering import DEFAULT_CLASS_DEFINITIONS_ORDER
 from .types import Range
 from . import (
     basic_checks,
@@ -56,22 +57,7 @@ DEFAULT_CONFIG = MappingProxyType(
         # unreachable # check in godot
         # using-constant-test # check in godot
         # class checks
-        "class-definitions-order": [
-            "tools",
-            "classnames",
-            "extends",
-            "docstrings",
-            "signals",
-            "enums",
-            "consts",
-            "staticvars",
-            "exports",
-            "pubvars",
-            "prvvars",
-            "onreadypubvars",
-            "onreadyprvvars",
-            "others",
-        ],
+        "class-definitions-order": list(DEFAULT_CLASS_DEFINITIONS_ORDER),
         # useless-super-delegation
         # design checks
         # max-locals

--- a/gdtoolkit/linter/class_checks.py
+++ b/gdtoolkit/linter/class_checks.py
@@ -4,11 +4,11 @@ from typing import List
 
 from lark import Tree
 
-from ..common.ast import AbstractSyntaxTree, Class, Statement, Annotation
-from ..common.utils import find_name_token_among_children, get_line, get_column
+from ..common.ast import AbstractSyntaxTree, Class
+from ..common.ordering import is_statement_irrelevant, map_statement_to_section
+from ..common.utils import get_line, get_column
 
 from .problem import Problem
-from .helpers import is_function_public
 
 
 def lint(parse_tree: Tree, config: MappingProxyType) -> List[Problem]:
@@ -43,11 +43,11 @@ def _class_definitions_order_check_for_class(
     problems = []
     current_section = order[0]
     for statement in a_class.statements:
-        if _is_statement_irrelevant(statement):
+        if is_statement_irrelevant(statement):
             continue
         try:
             current_section_rank = order.index(current_section)
-            statement_section = _map_statement_to_section(statement)
+            statement_section = map_statement_to_section(statement)
             section_rank = order.index(statement_section)
             if section_rank >= current_section_rank:
                 current_section = statement_section
@@ -77,61 +77,3 @@ def _class_definitions_order_check_for_class(
                 )
             )
     return problems
-
-
-def _is_statement_irrelevant(statement: Statement) -> bool:
-    if statement.kind == "pass_stmt":
-        return True
-    if statement.kind == "annotation":
-        return Annotation(statement.lark_node).name != "tool"
-    if statement.kind == "class_def":
-        return True
-    return False
-
-
-# pylint: disable-next=too-many-return-statements, too-many-branches
-def _map_statement_to_section(statement: Statement) -> str:
-    if statement.kind == "class_var_stmt":
-        if any(
-            annotation.name.startswith("export") for annotation in statement.annotations
-        ):
-            return "exports"
-        if any(annotation.name == "onready" for annotation in statement.annotations):
-            return "onready{}vars".format(
-                _class_var_stmt_visibility(statement.lark_node)
-            )
-        return "{}vars".format(_class_var_stmt_visibility(statement.lark_node))
-    if statement.kind == "signal_stmt":
-        return "signals"
-    if statement.kind == "extends_stmt":
-        return "extends"
-    if statement.kind == "classname_extends_stmt":
-        return "extends"
-    if statement.kind == "enum_stmt":
-        return "enums"
-    if statement.kind == "classname_stmt":
-        return "classnames"
-    if statement.kind == "const_stmt":
-        return "consts"
-    if (
-        statement.kind == "annotation"
-        and Annotation(statement.lark_node).name == "tool"
-    ):
-        return "tools"
-    if statement.kind == "func_def":
-        return "others"
-    if statement.kind == "static_func_def":
-        return "others"
-    if statement.kind == "abstract_func_def":
-        return "others"
-    if statement.kind == "docstr_stmt":
-        return "docstrings"
-    if statement.kind == "static_class_var_stmt":
-        return "staticvars"
-    raise NotImplementedError
-
-
-def _class_var_stmt_visibility(class_var_stmt: Tree) -> str:
-    some_var_stmt = class_var_stmt.children[0]
-    name_token = find_name_token_among_children(some_var_stmt)
-    return "pub" if is_function_public(name_token.value) else "prv"  # type: ignore

--- a/tests/formatter/test_executable.py
+++ b/tests/formatter/test_executable.py
@@ -201,3 +201,35 @@ def test_formatting_with_line_length_passed_as_argument(tmp_path):
         capture_output=True,
     )
     assert outcome.returncode == 1
+
+
+def test_out_of_order_file_left_unchanged_without_reorder(tmp_path):
+    dummy_file = write_file(tmp_path, "script.gd", "var x = 1\nsignal s\n")
+    outcome = subprocess.run(
+        ["gdformat", "--check", dummy_file], check=False, capture_output=True
+    )
+    assert outcome.returncode == 0
+    assert len(outcome.stderr.decode().splitlines()) == 0
+
+
+def test_out_of_order_file_reordered_with_reorder_flag(tmp_path):
+    dummy_file = write_file(tmp_path, "script.gd", "var x = 1\nsignal s\n")
+    outcome = subprocess.run(
+        ["gdformat", "--reorder-code", dummy_file], check=False, capture_output=True
+    )
+    assert outcome.returncode == 0, outcome.stderr.decode()
+    assert "Traceback" not in outcome.stderr.decode()
+    with open(dummy_file, "r", encoding="utf-8") as handle:
+        reordered = handle.read()
+    assert reordered.index("signal s") < reordered.index("var x")
+
+
+def test_out_of_order_file_check_with_reorder_flag(tmp_path):
+    dummy_file = write_file(tmp_path, "script.gd", "var x = 1\nsignal s\n")
+    outcome = subprocess.run(
+        ["gdformat", "--check", "--reorder-code", dummy_file],
+        check=False,
+        capture_output=True,
+    )
+    assert outcome.returncode == 1
+    assert "Traceback" not in outcome.stderr.decode()

--- a/tests/formatter/test_reordering.py
+++ b/tests/formatter/test_reordering.py
@@ -1,0 +1,113 @@
+import pytest
+
+from gdtoolkit.formatter import format_code, check_formatting_safety
+from gdtoolkit.linter import lint_code
+
+
+MAX_LINE_LENGTH = 100
+
+
+def _reorder(code, spaces_for_indent=None):
+    return format_code(
+        code,
+        max_line_length=MAX_LINE_LENGTH,
+        spaces_for_indent=spaces_for_indent,
+        reorder_code=True,
+    )
+
+
+# Exact input -> output pairs pinning the canonical ordering.
+# fmt: off
+EXACT_CASES = [
+    (
+        "var x\nsignal s\n",
+        "signal s\nvar x\n",
+    ),
+    (
+        "var x = 1\nconst C = 1\nextends Node\n@tool\n",
+        "@tool\nextends Node\nconst C = 1\nvar x = 1\n",
+    ),
+    (
+        "static func foo():\n\tpass\nstatic var sv = 1\nenum E { A, B }\n",
+        "enum E { A, B }\n\nstatic var sv = 1\n\n\nstatic func foo():\n\tpass\n",
+    ),
+    # comments and inline comments travel with their member
+    (
+        "# foo doc\nfunc foo():\n\tpass\nsignal s  # the signal\n",
+        "signal s  # the signal\n\n\n# foo doc\nfunc foo():\n\tpass\n",
+    ),
+    # @export / @onready stay attached; private sorts after public
+    (
+        "var pub\nvar _prv\n@onready var o = 1\n@export var e = 2\n",
+        "@export var e = 2\nvar pub\nvar _prv\n@onready var o = 1\n",
+    ),
+]
+# fmt: on
+
+
+@pytest.mark.parametrize("code,expected", EXACT_CASES)
+def test_reorder_exact_output(code, expected):
+    formatted = _reorder(code)
+    assert formatted == expected
+    check_formatting_safety(code, formatted, MAX_LINE_LENGTH, reorder_code=True)
+
+
+# Broader inputs (including every linter class-definitions-order failure case,
+# nested classes and property bodies) checked for the invariants that matter:
+# the result is lint-clean, idempotent, and passes the safety checks.
+# fmt: off
+INVARIANT_CASES = [
+    "var x\nsignal s\n",
+    "extends Node;var x\nsignal s\n",
+    "class X:\n\tvar x\n\textends Node\n",
+    "var _x\nvar x\n",
+    "@onready var x\nvar y\n",
+    "@onready var _x\n@onready var x\n",
+    "var x\nenum X { A, B }\n",
+    "var x\nclass_name Asdf\n",
+    "var x\nconst X = 1\n",
+    "var x\n@tool\n",
+    "static func foo(): pass\nvar x\n",
+    "'docstring'\nextends Node\n",
+    # nested class is reordered internally and sorts among functions/classes
+    "class Inner:\n\tfunc m():\n\t\tpass\n\tvar a = 1\n\tsignal inner_sig\n"
+    "var top = 1\nsignal top_sig\n",
+    # a property body must stay glued to its var when the var moves
+    "func foo():\n\tpass\nvar prop:\n\tget:\n\t\treturn prop\n"
+    "\tset(value):\n\t\tprop = value\nsignal s\n",
+    # comments must be preserved across reordering
+    "# leading\nfunc foo():\n\tpass\n\n# sig comment\nsignal s  # inline\nvar x = 1\n",
+]
+# fmt: on
+
+
+@pytest.mark.parametrize("code", INVARIANT_CASES)
+def test_reorder_is_lint_clean_idempotent_and_safe(code):
+    formatted = _reorder(code)
+    # safety checks (order-insensitive tree invariant, stability, comments)
+    check_formatting_safety(code, formatted, MAX_LINE_LENGTH, reorder_code=True)
+    # reordering its own output changes nothing
+    assert _reorder(formatted) == formatted
+    # the linter no longer complains about ordering
+    ordering_problems = [
+        problem
+        for problem in lint_code(formatted)
+        if problem.name == "class-definitions-order"
+    ]
+    assert ordering_problems == []
+
+
+def test_reorder_disabled_by_default():
+    code = "var x = 1\nsignal s\n"
+    formatted = format_code(code, max_line_length=MAX_LINE_LENGTH)
+    assert formatted.index("var x") < formatted.index("signal s")
+
+
+def test_reorder_with_spaces_for_indent():
+    code = "func foo():\n\tpass\nsignal s\n"
+    formatted = _reorder(code, spaces_for_indent=4)
+    check_formatting_safety(
+        code, formatted, MAX_LINE_LENGTH, spaces_for_indent=4, reorder_code=True
+    )
+    assert formatted.index("signal s") < formatted.index("func foo")
+    assert "\n    pass" in formatted


### PR DESCRIPTION
Reorders class-level members (signals, vars, functions, etc.) into the canonical order checked by gdlint's class-definitions-order rule. Opt-in via --reorder-code or reorder_code in gdformatrc; default off.

Reordering runs after a normal format pass and then reformats, moving whole formatted line-blocks so comments, annotations and property bodies travel with their member. The tree-invariant safety check is made order-insensitive at class scope when reordering, still catching any added/removed/mutated member. Classification logic is shared with the linter via gdtoolkit/common/ordering.py.